### PR TITLE
Update doubleCheck.js

### DIFF
--- a/web/doubleCheck.js
+++ b/web/doubleCheck.js
@@ -5,7 +5,7 @@ const BLUE = '🟦';
 const GREY = '⬛';
 
 export default function doubleCheck(state, api) {
-  const secret = prompt('What is your secret word?')?.toLowerCase();
+  const secret = prompt('What is your secret word?')?.toLowerCase().trim();
   if (secret == null) {
     return;
   }


### PR DESCRIPTION
Some devices add a space after the word when you override spell check, which causes a valid 5-letter word to be marked as invalid simply because it has a trailing space. This simply trims the whitespace at the end.